### PR TITLE
Update audienceType.ttl

### DIFF
--- a/audienceType.ttl
+++ b/audienceType.ttl
@@ -1,4 +1,4 @@
-@prefix audType: <http://purl.org/dcx/lrmiAudienceType/> .
+@prefix audRole: <http://purl.org/dcx/lrmiAudienceRole/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix schema: <http://schema.org/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -9,55 +9,55 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-<http://purl.org/dcx/lrmiAudienceType/> rdf:type skos:ConceptScheme;
-  dct:title "LRMI Audience Type Vocabulary";
+<http://purl.org/dcx/lrmiAudienceRole/> rdf:type skos:ConceptScheme;
+  dct:title "LRMI Educational Audience Role Vocabulary";
   dc:creator "LRMI Task Group (DCMI)"@en;
   dct:created "2015-01-21"^^xsd:date ;
   dct:license <http://creativecommons.org/licenses/by/4.0/>.
   
-audType:9b8b1d37-cbe3-472b-9bc6-eb67693006c8 rdf:type skos:Concept;
+audRole:001 rdf:type skos:Concept;
   skos:prefLabel "administrator"@en;
   skos:prefLabel "administrateur"@fr;
   skos:prefLabel "administrador"@es;
   skos:definition "A district or school level person of authority and responsibility"@en;
   skos:definition "Una persona distrito o la escuela de nivel de autoridad y responsabilidad"@es;
   skos:definition "Une personne au niveau du district ou de l'école de l'autorité et de la responsabilité"@fr;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.
 
-audType:93184541-bbcd-4613-844d-0d54e0b21c0d rdf:type skos:Concept;
+audRole:002 rdf:type skos:Concept;
   skos:prefLabel "mentor"@en;
   skos:altLabel "guide"@en, "guider"@fr, "guiar"@es;
   skos:definition "Someone who advises, trains, supports, and/or guides."@en;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.
 
-audType:9e8b8d04-47d8-4201-962c-19a3c8b1f7cf rdf:type skos:Concept;
+audRole:003 rdf:type skos:Concept;
   skos:prefLabel "general public"@en;
   skos:definition "The Public at large."@en;
   skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.
 
-audType:17c78c23-616f-468e-beb1-9aaf5181b14f rdf:type skos:Concept;
+audRole:004 rdf:type skos:Concept;
   skos:prefLabel "parent"@en;
   skos:definition "A parent or legal guardian."@en;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.  
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.  
        
-audType:457df3c5-247e-445a-bf3d-3145ce795961 rdf:type skos:Concept;
+audRole:005 rdf:type skos:Concept;
   skos:prefLabel "professional"@en;
   skos:definition "Someone already practicing a profession; an industry partner, or professional development trainer."@en;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.  
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.  
        
-audType:fc35bd68-f301-4ac2-8bdc-f965d2a26a0f rdf:type skos:Concept;
+audRole:006 rdf:type skos:Concept;
   skos:prefLabel "student"@en;
   skos:definition "The learner."@en;
   skos:narrower audType:a6760d5b-97b2-46ab-8b83-80ccd3f789d9;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.
   
-audType:a6760d5b-97b2-46ab-8b83-80ccd3f789d9 rdf:type skos:Concept;
+audRole:007 rdf:type skos:Concept;
   skos:prefLabel "peer/tutor"@en;
   skos:definition "The peer learner serving as tutor of another learner."@en;
   skos:broader audType:fc35bd68-f301-4ac2-8bdc-f965d2a26a0f;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.    
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.    
        
-audType:e9d882e6-e1b8-495c-803f-12fb832cc557 rdf:type skos:Concept;
+audRole:008 rdf:type skos:Concept;
   skos:prefLabel "teacher/education specialist"@en;
   skos:definition "A certified person directly involved with student instruction."@en;
-  skos:inScheme <http://purl.org/dcx/lrmiAudienceType/>.
+  skos:inScheme <http://purl.org/dcx/lrmiAudienceRole/>.


### PR DESCRIPTION
These edits include: (1) dropping the UUIDs and going with simple numerical sequencing given the size of the vocabulay; and (2) renaming the vocabulary Educational Audience Role.