### PR TITLE
Update educationalAudienceRole.ttl

### DIFF
--- a/educationalAudienceRole.ttl
+++ b/educationalAudienceRole.ttl
@@ -8,6 +8,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 
 <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/> rdf:type skos:ConceptScheme;
   dct:title "LRMI Educational Audience Role Vocabulary";
@@ -22,42 +23,50 @@ audRole:001 rdf:type skos:Concept;
   skos:definition "A district or school level person of authority and responsibility"@en;
   skos:definition "Una persona distrito o la escuela de nivel de autoridad y responsabilidad"@es;
   skos:definition "Une personne au niveau du district ou de l'école de l'autorité et de la responsabilité"@fr;
-  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>.
+  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>;
+  vs:term_status "unstable" .
 
 audRole:002 rdf:type skos:Concept;
   skos:prefLabel "mentor"@en;
   skos:altLabel "guide"@en, "guider"@fr, "guiar"@es;
   skos:definition "Someone who advises, trains, supports, and/or guides."@en;
-  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>.
+  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>;
+  vs:term_status "unstable" .
 
 audRole:003 rdf:type skos:Concept;
   skos:prefLabel "general public"@en;
   skos:definition "The Public at large."@en;
-  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>.
+  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>;
+  vs:term_status "unstable" .
 
 audRole:004 rdf:type skos:Concept;
   skos:prefLabel "parent"@en;
   skos:definition "A parent or legal guardian."@en;
-  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>.  
+  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>;
+  vs:term_status "unstable" .
        
 audRole:005 rdf:type skos:Concept;
   skos:prefLabel "professional"@en;
   skos:definition "Someone already practicing a profession; an industry partner, or professional development trainer."@en;
-  skos:inScheme <http://purl.org/dcx/educationalAudienceRole/>.  
+  skos:inScheme <http://purl.org/dcx/educationalAudienceRole/>;
+  vs:term_status "unstable" .
        
 audRole:006 rdf:type skos:Concept;
   skos:prefLabel "student"@en;
   skos:definition "The learner."@en;
   skos:narrower audType:007;
-  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>.
+  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>;
+  vs:term_status "unstable" .
   
 audRole:007 rdf:type skos:Concept;
   skos:prefLabel "peer/tutor"@en;
   skos:definition "The peer learner serving as tutor of another learner."@en;
   skos:broader audType:006;
-  skos:inScheme <http://purl.org/dcx/lrmi/educationalAudienceRole/>.    
+  skos:inScheme <http://purl.org/dcx/lrmi/educationalAudienceRole/>;
+  vs:term_status "unstable" .
        
 audRole:008 rdf:type skos:Concept;
   skos:prefLabel "teacher/education specialist"@en;
   skos:definition "A certified person directly involved with student instruction."@en;
-  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>.
+  skos:inScheme <http://purl.org/dcx/lrmi-vocabs/educationalAudienceRole/>;
+  vs:term_status "unstable" .


### PR DESCRIPTION
Added the <http://www.w3.org/2003/06/sw-vocab-status/ns#> namespace so we  can denote the status of terms at any particular stage. E.g., in this case, denoting all terms as "unstable" meaning: "The meaning, deployment practices, documentation (or important associated software/services) associated with this term are liable to change arbitrarily at some point in the future. They may not, but stability is not guaranteed. Use with caution."