### PR TITLE
Update educationalUse.ttl

### DIFF
--- a/educationalUse.ttl
+++ b/educationalUse.ttl
@@ -5,6 +5,7 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 
 # Defines a set of top-level concepts of Educational Use
 
@@ -15,16 +16,19 @@
     skos:prefLabel "instruction"@en ;
     skos:definition "Primary purpose of the resource is to support the instructional process, student learning, or to provide information about the curriculum."@en ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
-    skos:note "Based on the CEDS Learning Resource Educational Use term \"Curriculum/Instruction\" at https://ceds.ed.gov/element/001002."@en .
+    skos:note "Based on the CEDS Learning Resource Educational Use term \"Curriculum/Instruction\" at https://ceds.ed.gov/element/001002."@en ;
+    vs:term_status "unstable" .
     
 <http://purl.org/dcx/lrmi-vocabs/edUse/002> a skos:Concept ;
     skos:prefLabel "assessment"@en ;
     skos:definition "Primary purpose of the resource is to evaluate learning, either before or after instruction occurs."@en ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
-    skos:note "Based on the CEDS Learning Resource Educational Use term \"Assessment\" at https://ceds.ed.gov/element/001002."@en .
+    skos:note "Based on the CEDS Learning Resource Educational Use term \"Assessment\" at https://ceds.ed.gov/element/001002."@en ;
+    vs:term_status "unstable" .
 
 <http://purl.org/dcx/lrmi-vocabs/edUse/003> a skos:Concept ;
     skos:prefLabel "professional development"@en ;
     skos:definition "Primary purpose of the resource is to provide instruction for a teacher or other education professional."@en ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/edUse/> ;
-    skos:note "Based on the CEDS Learning Resource Educational Use term \"Professional Development\" at https://ceds.ed.gov/element/001002."@en .  
+    skos:note "Based on the CEDS Learning Resource Educational Use term \"Professional Development\" at https://ceds.ed.gov/element/001002."@en ;  
+    vs:term_status "unstable" .


### PR DESCRIPTION
Added <http://www.w3.org/2003/06/sw-vocab-status/ns#> namespace to support identifying the status of each term--here denoted as "unstable": "The meaning, deployment practices, documentation (or important associated software/services) associated with this term are liable to change arbitrarily at some point in the future. They may not, but stability is not guaranteed. Use with caution.
'testing'.