### PR TITLE
Update alignmentType.ttl

### DIFF
--- a/alignmentType.ttl
+++ b/alignmentType.ttl
@@ -12,15 +12,15 @@
 
 <http://purl.org/dcx/lrmi-vocabs/alignmentType/AT001> a skos:Concept ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/alignmentType/> ;
-    skos:prefLabel "assesses"@en .
+    skos:prefLabel "assessesCompetency"@en .
 
 <http://purl.org/dcx/lrmi-vocabs/alignmentType/AT002> a skos:Concept ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/alignmentType/> ;
-    skos:prefLabel "teaches"@en .
+    skos:prefLabel "teachesCompetency"@en .
 
 <http://purl.org/dcx/lrmi-vocabs/alignmentType/AT003> a skos:Concept ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/alignmentType/> ;
-    skos:prefLabel "requires"@en .
+    skos:prefLabel "requiresCompetency"@en .
 
 <http://purl.org/dcx/lrmi-vocabs/alignmentType/AT004> a skos:Concept ;
     skos:inScheme <http://purl.org/dcx/lrmi-vocabs/alignmentType/> ;


### PR DESCRIPTION
Propose refinement of the teaches, assesses, requires to to specifically relate the learning resource to a compenecy node in a competency framework. Uncertain of their application otherwise than in the context of competency rameworks.